### PR TITLE
Update Lab 0601 to remove some ambiguity

### DIFF
--- a/Instructions/Labs/0601-Configure and Deploy Windows Information Protection Policies by using Intune.md
+++ b/Instructions/Labs/0601-Configure and Deploy Windows Information Protection Policies by using Intune.md
@@ -106,7 +106,7 @@ To following lab(s) must be completed before this lab:
 
 1. On the taskbar, select **Microsoft Edge**.
 
-2. Open **Microsoft Edge**, and navigate to `https://yourtenant.sharepoint.com`.
+2. Open **Microsoft Edge**, and navigate to `https://<yourtenant>.sharepoint.com`.
 
    > Take note of the briefcase icon at the right side of the address bar. Select the icon and verify that this website is managed by the tenant. It may take a while for the briefcase icon to appear. If it does not appear after 5 minutes, skip to Task 6 to complete the alternate task to test WIP.
 


### PR DESCRIPTION
When I was doing this lab, I encountered a problem where I thought that yourtenant.sharepoint.com was supposed to be typed literally. This was caused by the fact that  there was no < > to state that we were supposed to substitute a domain name into this field.